### PR TITLE
Update to 1.21.11

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -73,9 +73,9 @@ publishMods {
     github {
         repository = "TheDeathlyCow/novoatlas"
         accessToken = providers.environmentVariable("RELEASE_GITHUB_TOKEN")
-        commitish = "1.21.9"
+        commitish = "1.21.11"
         tagName = "${mod_version}"
 
-        displayName = "[1.21.9-10] NovoAtlas Example Datapacks ${mod_version}"
+        displayName = "[1.21.9-11] NovoAtlas Example Datapacks ${mod_version}"
     }
 }

--- a/common/src/main/java/com/thedeathlycow/novoatlas/NovoAtlas.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/NovoAtlas.java
@@ -1,6 +1,6 @@
 package com.thedeathlycow.novoatlas;
 
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,8 +12,8 @@ public final class NovoAtlas {
         // Write common init code here.
     }
 
-    public static ResourceLocation loc(String path) {
-        return ResourceLocation.fromNamespaceAndPath(MOD_ID, path);
+    public static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath(MOD_ID, path);
     }
 
     private NovoAtlas() {

--- a/common/src/main/java/com/thedeathlycow/novoatlas/registry/ImageManager.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/registry/ImageManager.java
@@ -4,7 +4,7 @@ import com.thedeathlycow.novoatlas.NovoAtlas;
 import com.thedeathlycow.novoatlas.world.gen.MapImage;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import org.jetbrains.annotations.Nullable;
@@ -38,14 +38,14 @@ public final class ImageManager {
         if (NovoAtlas.LOGGER.isInfoEnabled()) {
             NovoAtlas.LOGGER.info(
                     "Reloading map images for {}, supported image formats are: {}",
-                    registryKey.location(),
+                    registryKey.identifier(),
                     Arrays.toString(converter.getExtensions())
             );
         }
 
-        Map<ResourceLocation, Resource> resources = converter.listMatchingResources(resourceManager);
+        Map<Identifier, Resource> resources = converter.listMatchingResources(resourceManager);
 
-        for (Map.Entry<ResourceLocation, Resource> entry : resources.entrySet()) {
+        for (Map.Entry<Identifier, Resource> entry : resources.entrySet()) {
             BufferedImage image;
             try (InputStream stream = entry.getValue().open()) {
                 image = ImageIO.read(stream);
@@ -59,13 +59,13 @@ public final class ImageManager {
             if (updatedRegistry.put(key, map) != null) {
                 final String message = "Found duplicate image files for {}, overriding with {} " +
                         "(images of the different types should have different names)";
-                NovoAtlas.LOGGER.warn(message, key.location(), entry.getKey());
+                NovoAtlas.LOGGER.warn(message, key.identifier(), entry.getKey());
             }
         }
 
         this.registry.clear();
         this.registry.putAll(updatedRegistry);
-        NovoAtlas.LOGGER.info("Loaded {} map image(s) for {}", this.registry.size(), registryKey.location());
+        NovoAtlas.LOGGER.info("Loaded {} map image(s) for {}", this.registry.size(), registryKey.identifier());
     }
 
     @Nullable

--- a/common/src/main/java/com/thedeathlycow/novoatlas/registry/MultiFileTypeToIdConverter.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/registry/MultiFileTypeToIdConverter.java
@@ -5,7 +5,7 @@ import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.FileToIdConverter;
 import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 
@@ -35,7 +35,7 @@ public class MultiFileTypeToIdConverter {
         return builtinImages(getElementsPath(registryKey));
     }
 
-    public ResourceLocation fileToId(ResourceLocation file) {
+    public Identifier fileToId(Identifier file) {
         String path = file.getPath();
 
         for (String extension : this.extensions) {
@@ -50,11 +50,11 @@ public class MultiFileTypeToIdConverter {
         throw new IllegalArgumentException(message);
     }
 
-    public Map<ResourceLocation, Resource> listMatchingResources(ResourceManager resourceManager) {
+    public Map<Identifier, Resource> listMatchingResources(ResourceManager resourceManager) {
         return resourceManager.listResources(this.prefix, this::test);
     }
 
-    public Map<ResourceLocation, List<Resource>> listMatchingResourceStacks(ResourceManager resourceManager) {
+    public Map<Identifier, List<Resource>> listMatchingResourceStacks(ResourceManager resourceManager) {
         return resourceManager.listResourceStacks(this.prefix, this::test);
     }
 
@@ -62,17 +62,17 @@ public class MultiFileTypeToIdConverter {
         return this.extensions;
     }
 
-    private boolean test(ResourceLocation location) {
+    private boolean test(Identifier location) {
         return Arrays.stream(this.extensions).anyMatch(extension -> location.getPath().endsWith(extension));
     }
 
     private static String getElementsPath(ResourceKey<? extends Registry<?>> registryKey) {
-        String namespace = registryKey.location().getNamespace();
+        String namespace = registryKey.identifier().getNamespace();
 
-        if (namespace.equals(ResourceLocation.DEFAULT_NAMESPACE)) {
+        if (namespace.equals(Identifier.DEFAULT_NAMESPACE)) {
             return Registries.elementsDirPath(registryKey);
         } else {
-            return "%s/%s".formatted(namespace, registryKey.location().getPath());
+            return "%s/%s".formatted(namespace, registryKey.identifier().getPath());
         }
     }
 }

--- a/common/src/main/java/com/thedeathlycow/novoatlas/registry/NovoAtlasResourceKeys.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/registry/NovoAtlasResourceKeys.java
@@ -8,15 +8,15 @@ import net.minecraft.resources.ResourceKey;
 
 public final class NovoAtlasResourceKeys {
     public static final ResourceKey<Registry<MapInfo>> MAP_INFO = ResourceKey.createRegistryKey(
-            NovoAtlas.loc("map_info")
+            NovoAtlas.id("map_info")
     );
 
     public static final ResourceKey<Registry<MapImage>> HEIGHTMAP = ResourceKey.createRegistryKey(
-            NovoAtlas.loc("heightmap")
+            NovoAtlas.id("heightmap")
     );
 
     public static final ResourceKey<Registry<MapImage>> BIOME_MAP = ResourceKey.createRegistryKey(
-            NovoAtlas.loc("biome_map")
+            NovoAtlas.id("biome_map")
     );
 
     private NovoAtlasResourceKeys() {

--- a/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/biome/provider/LayeredMapBiomeProvider.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/biome/provider/LayeredMapBiomeProvider.java
@@ -19,7 +19,7 @@ public record LayeredMapBiomeProvider(
 ) implements BiomeMapProvider {
     public static final ResourceKey<Biome> SURFACE_BIOME = ResourceKey.create(
             Registries.BIOME,
-            NovoAtlas.loc("surface_biome")
+            NovoAtlas.id("surface_biome")
     );
 
     public static final MapCodec<LayeredMapBiomeProvider> CODEC = RecordCodecBuilder.mapCodec(

--- a/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/function/load.mcfunction
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/function/load.mcfunction
@@ -1,0 +1,1 @@
+tellraw @a ["The Avila example pack is loaded in a separate dimension, click ",{"click_event":{"action":"run_command","command":"execute in avila-example:avila run teleport @s 0 200 0"},"color":"green","text":"[here]"}," to teleport there."]

--- a/common/src/main/resources/resourcepacks/avila-basic-example/data/minecraft/tags/function/load.json
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/data/minecraft/tags/function/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "avila-example:load"
+    ]
+}

--- a/common/src/main/resources/resourcepacks/avila-basic-example/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/pack.mcmeta
@@ -1,12 +1,12 @@
 {
   "pack": {
     "description": "Avila mountains example dimension created using NovoAtlas",
-    "pack_format": 88,
-    "min_format": 57,
-    "max_format": 88,
-    "supported_formats": {
-      "min_inclusive": 57,
-      "max_inclusive": 88
-    }
+      "pack_format": 94,
+      "min_format": 57,
+      "max_format": 94,
+      "supported_formats": {
+          "min_inclusive": 57,
+          "max_inclusive": 94
+      }
   }
 }

--- a/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/avila-example/function/load.mcfunction
+++ b/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/avila-example/function/load.mcfunction
@@ -1,0 +1,1 @@
+tellraw @a ["The Avila example pack is loaded in a separate dimension, click ",{"click_event":{"action":"run_command","command":"execute in avila-example:avila run teleport @s 0 200 0"},"color":"green","text":"[here]"}," to teleport there."]

--- a/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/minecraft/tags/function/load.json
+++ b/common/src/main/resources/resourcepacks/avila-cave-biome-example/data/minecraft/tags/function/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "avila-example:load"
+    ]
+}

--- a/common/src/main/resources/resourcepacks/avila-cave-biome-example/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/avila-cave-biome-example/pack.mcmeta
@@ -1,12 +1,12 @@
 {
-  "pack": {
-    "description": "Avila mountains example dimension created using NovoAtlas with cave biomes",
-    "pack_format": 88,
-    "min_format": 57,
-    "max_format": 88,
-    "supported_formats": {
-      "min_inclusive": 57,
-      "max_inclusive": 88
+    "pack": {
+        "description": "Avila mountains example dimension created using NovoAtlas with cave biomes",
+        "pack_format": 94,
+        "min_format": 57,
+        "max_format": 94,
+        "supported_formats": {
+            "min_inclusive": 57,
+            "max_inclusive": 94
+        }
     }
-  }
 }

--- a/common/src/main/resources/resourcepacks/avila-no-caves-example/data/avila-example/function/load.mcfunction
+++ b/common/src/main/resources/resourcepacks/avila-no-caves-example/data/avila-example/function/load.mcfunction
@@ -1,0 +1,1 @@
+tellraw @a ["The Avila example pack is loaded in a separate dimension, click ",{"click_event":{"action":"run_command","command":"execute in avila-example:avila run teleport @s 0 200 0"},"color":"green","text":"[here]"}," to teleport there."]

--- a/common/src/main/resources/resourcepacks/avila-no-caves-example/data/minecraft/tags/function/load.json
+++ b/common/src/main/resources/resourcepacks/avila-no-caves-example/data/minecraft/tags/function/load.json
@@ -1,0 +1,5 @@
+{
+    "values": [
+        "avila-example:load"
+    ]
+}

--- a/common/src/main/resources/resourcepacks/avila-no-caves-example/pack.mcmeta
+++ b/common/src/main/resources/resourcepacks/avila-no-caves-example/pack.mcmeta
@@ -1,12 +1,12 @@
 {
-  "pack": {
-    "description": "Avila mountains example dimension created using NovoAtlas with no caves",
-    "pack_format": 88,
-    "min_format": 57,
-    "max_format": 88,
-    "supported_formats": {
-      "min_inclusive": 57,
-      "max_inclusive": 88
+    "pack": {
+        "description": "Avila mountains example dimension created using NovoAtlas with no caves",
+        "pack_format": 94,
+        "min_format": 57,
+        "max_format": 94,
+        "supported_formats": {
+            "min_inclusive": 57,
+            "max_inclusive": 94
+        }
     }
-  }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -99,7 +99,7 @@ publishMods {
     curseforge {
         accessToken = providers.environmentVariable("CURSEFORGE_API_KEY")
         projectId = "1297254"
-        minecraftVersions.addAll("1.21.9", "1.21.10")
+        minecraftVersions.addAll("1.21.9", "1.21.10", "1.21.11")
 
         javaVersions.add(JavaVersion.VERSION_21)
 
@@ -114,7 +114,7 @@ publishMods {
     modrinth {
         accessToken = providers.environmentVariable("MODRINTH_TOKEN")
         projectId = "yh3a3Yc8"
-        minecraftVersions.addAll("1.21.9", "1.21.10")
+        minecraftVersions.addAll("1.21.9", "1.21.10", "1.21.11")
 
         requires("fabric-api")
 

--- a/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/MapImageLoader.java
+++ b/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/MapImageLoader.java
@@ -3,14 +3,14 @@ package com.thedeathlycow.novoatlas.fabric;
 import com.thedeathlycow.novoatlas.NovoAtlas;
 import com.thedeathlycow.novoatlas.registry.ImageManager;
 import net.fabricmc.fabric.api.resource.SimpleSynchronousResourceReloadListener;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.ResourceManager;
 
 public class MapImageLoader implements SimpleSynchronousResourceReloadListener {
-    public static final ResourceLocation ID = NovoAtlas.loc("map_image");
+    public static final Identifier ID = NovoAtlas.id("map_image");
 
     @Override
-    public ResourceLocation getFabricId() {
+    public Identifier getFabricId() {
         return ID;
     }
 

--- a/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/NovoAtlasFabric.java
+++ b/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/NovoAtlasFabric.java
@@ -24,10 +24,10 @@ public final class NovoAtlasFabric implements ModInitializer {
 
         DynamicRegistries.register(NovoAtlasResourceKeys.MAP_INFO, MapInfo.DIRECT_CODEC);
 
-        Registry.register(BuiltInRegistries.CHUNK_GENERATOR, NovoAtlas.loc("image_map"), ImageMapChunkGenerator.CODEC);
-        Registry.register(BuiltInRegistries.BIOME_SOURCE, NovoAtlas.loc("color_map"), ColorMapBiomeSource.CODEC);
-        Registry.register(BuiltInRegistries.DENSITY_FUNCTION_TYPE, NovoAtlas.loc("heightmap"), HeightmapDensityFunction.DATA_CODEC);
-        Registry.register(BuiltInRegistries.DENSITY_FUNCTION_TYPE, NovoAtlas.loc("get_height_from_map"), GetHeightFromMapDensityFunction.DATA_CODEC);
+        Registry.register(BuiltInRegistries.CHUNK_GENERATOR, NovoAtlas.id("image_map"), ImageMapChunkGenerator.CODEC);
+        Registry.register(BuiltInRegistries.BIOME_SOURCE, NovoAtlas.id("color_map"), ColorMapBiomeSource.CODEC);
+        Registry.register(BuiltInRegistries.DENSITY_FUNCTION_TYPE, NovoAtlas.id("heightmap"), HeightmapDensityFunction.DATA_CODEC);
+        Registry.register(BuiltInRegistries.DENSITY_FUNCTION_TYPE, NovoAtlas.id("get_height_from_map"), GetHeightFromMapDensityFunction.DATA_CODEC);
 
         ResourceManagerHelper serverManager = ResourceManagerHelper.get(PackType.SERVER_DATA);
         serverManager.registerReloadListener(new MapImageLoader());
@@ -39,19 +39,19 @@ public final class NovoAtlasFabric implements ModInitializer {
                 : ResourcePackActivationType.NORMAL;
 
         ResourceManagerHelper.registerBuiltinResourcePack(
-                NovoAtlas.loc("avila-basic-example"),
+                NovoAtlas.id("avila-basic-example"),
                 mod,
                 activationType
         );
 
         ResourceManagerHelper.registerBuiltinResourcePack(
-                NovoAtlas.loc("avila-cave-biome-example"),
+                NovoAtlas.id("avila-cave-biome-example"),
                 mod,
                 ResourcePackActivationType.NORMAL
         );
 
         ResourceManagerHelper.registerBuiltinResourcePack(
-                NovoAtlas.loc("avila-no-caves-example"),
+                NovoAtlas.id("avila-no-caves-example"),
                 mod,
                 ResourcePackActivationType.NORMAL
         );

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
         "novoatlas.mixins.json"
     ],
     "depends": {
-        "fabricloader": ">=0.16.13",
+        "fabricloader": ">=0.18.4",
         "minecraft": ">=1.21.9",
         "java": ">=21",
         "fabric-api": "*"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,19 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.4.0
+mod_version = 1.5.0-SNAPSHOT
 maven_group = com.thedeathlycow.novoatlas
 archives_name = novoatlas
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 1.21.10
+minecraft_version = 1.21.11
 
 # Dependencies
-fabric_loader_version = 0.18.1
-fabric_api_version = 0.138.3+1.21.10
-neoforge_version = 21.10.64
+fabric_loader_version = 0.18.4
+fabric_api_version = 0.140.2+1.21.11
+neoforge_version = 21.11.17-beta
 twelvemonkeys_imageio_version = 3.12.0
 
 # Integrations
-terrablender_version = 1.21.10-21.10.0.0
+terrablender_version = 1.21.11-21.11.0.0

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -101,7 +101,7 @@ publishMods {
     curseforge {
         accessToken = providers.environmentVariable("CURSEFORGE_API_KEY")
         projectId = "1297254"
-        minecraftVersions.addAll("1.21.9", "1.21.10")
+        minecraftVersions.addAll("1.21.11")
 
         javaVersions.add(JavaVersion.VERSION_21)
 
@@ -114,7 +114,7 @@ publishMods {
     modrinth {
         accessToken = providers.environmentVariable("MODRINTH_TOKEN")
         projectId = "yh3a3Yc8"
-        minecraftVersions.addAll("1.21.9", "1.21.10")
+        minecraftVersions.addAll("1.21.11")
 
         optional("terrablender")
     }

--- a/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/MapImageLoader.java
+++ b/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/MapImageLoader.java
@@ -2,12 +2,12 @@ package com.thedeathlycow.novoatlas.neoforge;
 
 import com.thedeathlycow.novoatlas.NovoAtlas;
 import com.thedeathlycow.novoatlas.registry.ImageManager;
-import net.minecraft.resources.ResourceLocation;
+import net.minecraft.resources.Identifier;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 
 public class MapImageLoader implements ResourceManagerReloadListener {
-    public static final ResourceLocation ID = NovoAtlas.loc("map_image");
+    public static final Identifier ID = NovoAtlas.id("map_image");
 
     @Override
     public void onResourceManagerReload(ResourceManager resourceManager) {

--- a/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/NovoAtlasNeoForge.java
+++ b/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/NovoAtlasNeoForge.java
@@ -7,8 +7,6 @@ import com.thedeathlycow.novoatlas.world.gen.ImageMapChunkGenerator;
 import com.thedeathlycow.novoatlas.world.gen.HeightmapDensityFunction;
 import com.thedeathlycow.novoatlas.world.gen.MapInfo;
 import com.thedeathlycow.novoatlas.world.gen.biome.ColorMapBiomeSource;
-import net.minecraft.core.Registry;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.packs.PackType;
@@ -42,7 +40,7 @@ public final class NovoAtlasNeoForge {
                     : PackSource.WORLD;
 
             event.addPackFinders(
-                    NovoAtlas.loc("resourcepacks/avila-basic-example"),
+                    NovoAtlas.id("resourcepacks/avila-basic-example"),
                     PackType.SERVER_DATA,
                     Component.literal("novoatlas/avila-basic-example"),
                     packSource,
@@ -51,7 +49,7 @@ public final class NovoAtlasNeoForge {
             );
 
             event.addPackFinders(
-                    NovoAtlas.loc("resourcepacks/avila-cave-biome-example"),
+                    NovoAtlas.id("resourcepacks/avila-cave-biome-example"),
                     PackType.SERVER_DATA,
                     Component.literal("novoatlas/avila-cave-biome-example"),
                     PackSource.FEATURE,
@@ -60,7 +58,7 @@ public final class NovoAtlasNeoForge {
             );
 
             event.addPackFinders(
-                    NovoAtlas.loc("resourcepacks/avila-no-caves-example"),
+                    NovoAtlas.id("resourcepacks/avila-no-caves-example"),
                     PackType.SERVER_DATA,
                     Component.literal("novoatlas/avila-no-caves-example"),
                     PackSource.FEATURE,
@@ -71,10 +69,10 @@ public final class NovoAtlasNeoForge {
     }
 
     private static void register(RegisterEvent event) {
-        event.register(Registries.CHUNK_GENERATOR, NovoAtlas.loc("image_map"), () -> ImageMapChunkGenerator.CODEC);
-        event.register(Registries.BIOME_SOURCE, NovoAtlas.loc("color_map"), () -> ColorMapBiomeSource.CODEC);
-        event.register(Registries.DENSITY_FUNCTION_TYPE, NovoAtlas.loc("heightmap"), () -> HeightmapDensityFunction.DATA_CODEC);
-        event.register(Registries.DENSITY_FUNCTION_TYPE, NovoAtlas.loc("get_height_from_map"), () -> GetHeightFromMapDensityFunction.DATA_CODEC);
+        event.register(Registries.CHUNK_GENERATOR, NovoAtlas.id("image_map"), () -> ImageMapChunkGenerator.CODEC);
+        event.register(Registries.BIOME_SOURCE, NovoAtlas.id("color_map"), () -> ColorMapBiomeSource.CODEC);
+        event.register(Registries.DENSITY_FUNCTION_TYPE, NovoAtlas.id("heightmap"), () -> HeightmapDensityFunction.DATA_CODEC);
+        event.register(Registries.DENSITY_FUNCTION_TYPE, NovoAtlas.id("get_height_from_map"), () -> GetHeightFromMapDensityFunction.DATA_CODEC);
 
     }
 

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,14 +16,14 @@ logoFile = "assets/novoatlas/icon.png"
 [[dependencies.novoatlas]]
 modId = "neoforge"
 type = "required"
-versionRange = "[21.9,)"
+versionRange = "[21.11,)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.novoatlas]]
 modId = "minecraft"
 type = "required"
-versionRange = "[1.21.9,)"
+versionRange = "[1.21.11,)"
 ordering = "NONE"
 side = "BOTH"
 


### PR DESCRIPTION
The only real update here is that Neoforge needed the `ResourceLocation` class to be renamed to `Identifier`. Fabric still works with 1.21.9-11 (yay intermediary).

Also added a load function to the example packs to help people find the avila dimension more easily.