### PR TITLE
[26.1.x] Lanczos Interpolation

### DIFF
--- a/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/MapScaleConfig.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/MapScaleConfig.java
@@ -48,7 +48,7 @@ public record MapScaleConfig(
                             if (config.interpolation == DEFAULT.interpolation()) {
                                 return DataResult.success(config.value);
                             } else {
-                                return DataResult.error(() -> "Non-bilinear horizontal config cannot map to float " + config);
+                                return DataResult.error(() -> "Only a nearest neighbour interpolator can be mapped to a float, but was given:" + config);
                             }
                         }
                 );

--- a/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/interpolation/Interpolator.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/interpolation/Interpolator.java
@@ -1,5 +1,6 @@
 package com.thedeathlycow.novoatlas.world.gen.interpolation;
 
+import com.google.common.base.Preconditions;
 import com.mojang.serialization.MapCodec;
 import com.thedeathlycow.novoatlas.registry.NovoAtlasBuiltinRegistries;
 import com.thedeathlycow.novoatlas.world.gen.MapImage;
@@ -28,5 +29,10 @@ public interface Interpolator {
 
     static Interpolator bicubic() {
         return new Bicubic();
+    }
+
+    static Interpolator lanczos(int window) {
+        Preconditions.checkArgument(window > 0, "Lanczos window must be positive");
+        return new Lanczos(window);
     }
 }

--- a/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/interpolation/Lanczos.java
+++ b/common/src/main/java/com/thedeathlycow/novoatlas/world/gen/interpolation/Lanczos.java
@@ -1,0 +1,69 @@
+package com.thedeathlycow.novoatlas.world.gen.interpolation;
+
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import com.thedeathlycow.novoatlas.world.gen.MapImage;
+import net.minecraft.util.ExtraCodecs;
+
+/// Implementation based on [Lánczos interpolation explained](https://mazzo.li/posts/lanczos.html).
+public record Lanczos(
+        int window
+) implements Interpolator {
+    public static final MapCodec<Lanczos> CODEC = RecordCodecBuilder.mapCodec(
+            instance -> instance.group(
+                    ExtraCodecs.POSITIVE_INT
+                            .optionalFieldOf("window", 3)
+                            .forGetter(Lanczos::window)
+            ).apply(instance, Lanczos::new)
+    );
+
+    @Override
+    public double sample(double x, double z, MapImage image) {
+        // x and z are the truncated (floor) coordinates
+        // deltaX and deltaZ are the fractional parts
+        double truncatedX = Math.floor(x);
+        double truncatedZ = Math.floor(z);
+
+        // x - truncatedX gets the fractional part of the sampled point, to use for lerp deltas
+        double deltaX = x - truncatedX;
+        double deltaZ = z - truncatedZ;
+
+        double result = 0.0;
+        double totalWeight = 0.0;
+
+        // for loops provide a convolution
+        for (int dx = -window; dx <= window; dx++) {
+            for (int dz = -window; dz <= window; dz++) {
+                double tX = Math.clamp(truncatedX + dx, 0, image.width() - 1.0);
+                double tZ = Math.clamp(truncatedZ + dz, 0, image.height() - 1.0);
+
+                // combine lanczos smoothing across x and z axes
+                double smoothing = lanczosSmoothing1d(deltaX - dx) * lanczosSmoothing1d(deltaZ - dz);
+
+                result += image.getTruncated(tX, tZ) * smoothing;
+                totalWeight += smoothing;
+            }
+        }
+
+        // normalizing for total weight seems to fix weird issues
+        return totalWeight == 0 ? 0 : result / totalWeight;
+    }
+
+    @Override
+    public MapCodec<Lanczos> codec() {
+        return CODEC;
+    }
+
+    private double lanczosSmoothing1d(double t) {
+        if (Math.abs(t) >= this.window) {
+            return 0;
+        }
+
+        double piT = Math.PI * t;
+        return sinc(piT) * sinc(piT / this.window);
+    }
+
+    private static double sinc(double x) {
+        return x == 0 ? 1 : Math.sin(x) / x;
+    }
+}

--- a/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
@@ -1,7 +1,11 @@
 {
     "starting_y": 6,
     "scaling": {
-        "horizontal_scale": 1,
+        "horizontal_scale": {
+            "interpolation": "lanczos",
+            "value": 5,
+            "window": 2
+        },
         "vertical_scale": 1
     },
     "height_map": "avila-example:avila",

--- a/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
+++ b/common/src/main/resources/resourcepacks/avila-basic-example/data/avila-example/novoatlas/map_info/avila.json
@@ -1,11 +1,7 @@
 {
     "starting_y": 6,
     "scaling": {
-        "horizontal_scale": {
-            "interpolation": "lanczos",
-            "value": 5,
-            "window": 2
-        },
+        "horizontal_scale": 1,
         "vertical_scale": 1
     },
     "height_map": "avila-example:avila",

--- a/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/NovoAtlasFabric.java
+++ b/fabric/src/main/java/com/thedeathlycow/novoatlas/fabric/NovoAtlasFabric.java
@@ -12,6 +12,7 @@ import com.thedeathlycow.novoatlas.world.gen.MapInfo;
 import com.thedeathlycow.novoatlas.world.gen.biome.ColorMapBiomeSource;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.Bicubic;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.Bilinear;
+import com.thedeathlycow.novoatlas.world.gen.interpolation.Lanczos;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.NearestNeighbour;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
@@ -38,10 +39,12 @@ public final class NovoAtlasFabric implements ModInitializer {
         Registry.register(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("nearest_neighbor"), NearestNeighbour.CODEC);
         Registry.register(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bilinear"), Bilinear.CODEC);
         Registry.register(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bicubic"), Bicubic.CODEC);
+        Registry.register(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("lanczos"), Lanczos.CODEC);
 
         addDefaultAlias(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("nearest_neighbor"));
         addDefaultAlias(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bilinear"));
         addDefaultAlias(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bicubic"));
+        addDefaultAlias(NovoAtlasBuiltinRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("lanczos"));
 
         ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(NovoAtlasRegistries.HEIGHTMAP.identifier(), ImageManager.HEIGHTMAP);
         ResourceLoader.get(PackType.SERVER_DATA).registerReloadListener(NovoAtlasRegistries.BIOME_MAP.identifier(), ImageManager.BIOME_MAP);

--- a/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/NovoAtlasNeoForge.java
+++ b/neoforge/src/main/java/com/thedeathlycow/novoatlas/neoforge/NovoAtlasNeoForge.java
@@ -11,6 +11,7 @@ import com.thedeathlycow.novoatlas.world.gen.MapInfo;
 import com.thedeathlycow.novoatlas.world.gen.biome.ColorMapBiomeSource;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.Bicubic;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.Bilinear;
+import com.thedeathlycow.novoatlas.world.gen.interpolation.Lanczos;
 import com.thedeathlycow.novoatlas.world.gen.interpolation.NearestNeighbour;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.Registries;
@@ -91,10 +92,12 @@ public final class NovoAtlasNeoForge {
             event.register(NovoAtlasRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("nearest_neighbor"), () -> NearestNeighbour.CODEC);
             event.register(NovoAtlasRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bilinear"), () -> Bilinear.CODEC);
             event.register(NovoAtlasRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("bicubic"), () -> Bicubic.CODEC);
+            event.register(NovoAtlasRegistries.INTERPOLATOR_TYPE, NovoAtlas.id("lanczos"), () -> Lanczos.CODEC);
 
             addDefaultAlias(event.getRegistry(), NovoAtlas.id("nearest_neighbor"));
             addDefaultAlias(event.getRegistry(), NovoAtlas.id("bilinear"));
             addDefaultAlias(event.getRegistry(), NovoAtlas.id("bicubic"));
+            addDefaultAlias(event.getRegistry(), NovoAtlas.id("lanczos"));
         }
     }
 


### PR DESCRIPTION
Supersedes #8. 

Implements lanczos interpolation using the new interpolation type registry system to allow for users to configure custom window sizes. Implementation was based on [this article](https://mazzo.li/posts/lanczos.html). 

To me, it looks mostly similar to bicubic but has slightly less of the repeatitive curve artefacts. Some screenshots for comparison are provided below...

**Lanczos at value=5, window=3:**
<img width="2560" height="1441" alt="image" src="https://github.com/user-attachments/assets/aef8ff76-4456-4827-bf8c-c40ac6fba158" />

**Lanczos at value=5, window=2:**
<img width="2560" height="1441" alt="image" src="https://github.com/user-attachments/assets/ec612c6d-2bea-4c5f-b267-0ce8920d3a83" />

**Bicubic at value=5:**
<img width="2560" height="1441" alt="image" src="https://github.com/user-attachments/assets/42e7ee18-cdb5-49e6-8ed7-9743c353c6c7" />

